### PR TITLE
fix: add smoke test and metrics response

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,22 +107,7 @@ clean:
 
 smoke:
 	@echo "🚬 Smoke testing API..."
-	@python - <<'PY'
-import time, threading, sys
-from uvicorn import Config, Server
-from apps.api.olympus_api.main import app
-cfg = Config(app=app, host="127.0.0.1", port=8000, log_level="warning")
-svr = Server(cfg)
-t = threading.Thread(target=lambda: sys.exit(svr.run()))
-t.daemon = True
-t.start()
-time.sleep(1.0)
-import httpx
-with httpx.Client() as c:
-    r = c.get("http://127.0.0.1:8000/health"); assert r.status_code == 200
-    r = c.get("http://127.0.0.1:8000/metrics"); assert r.status_code == 200
-	print("OK")
-PY
+	@python scripts/smoke.py
 
 # Run llama.cpp server (llama-cpp-python) for local dev
 # Usage: make llamacpp-run MODEL=your_model.gguf [HOST=127.0.0.1 PORT=8080]

--- a/README.md
+++ b/README.md
@@ -54,8 +54,11 @@ Open a browser at `http://127.0.0.1:8000/ui` for a simple chat page.
 
 4) Talk to Olympus in natural language
 - In a third terminal, try:
-  - `curl -sS -X POST http://127.0.0.1:8000/v1/agent/chat -H 'content-type: application/json' -d '{"message":"Format, type‑check and test the project"}' | jq .`
+ - `curl -sS -X POST http://127.0.0.1:8000/v1/agent/chat -H 'content-type: application/json' -d '{"message":"Format, type‑check and test the project"}' | jq .`
 - Olympus will reply. If a task needs permission (like writing files or running commands), it will ask first.
+
+5) Verify the API
+- `make smoke` checks the health and metrics endpoints
 
 ## LLM Setup (your local model)
 

--- a/apps/api/olympus_api/main.py
+++ b/apps/api/olympus_api/main.py
@@ -10,18 +10,37 @@ from typing import Any, Dict, List, Optional
 from fastapi import BackgroundTasks, FastAPI, HTTPException, Request, Depends
 from fastapi.middleware.cors import CORSMiddleware
 from starlette.staticfiles import StaticFiles
-from fastapi.responses import JSONResponse
-from prometheus_client import CONTENT_TYPE_LATEST, Counter, Gauge, Histogram, CollectorRegistry, generate_latest
+from fastapi.responses import Response
+from prometheus_client import (
+    CONTENT_TYPE_LATEST,
+    Counter,
+    Gauge,
+    Histogram,
+    CollectorRegistry,
+    generate_latest,
+)
 from pydantic import BaseModel, Field
 import requests
 from fastapi.responses import StreamingResponse
 
 from packages.memory.olympus_memory.db import MemoryDB
-from packages.plan.olympus_plan.models import CapabilityRef, Guard, Plan, PlanEvent, PlanState, Step, StepState
+from packages.plan.olympus_plan.models import (
+    CapabilityRef,
+    Guard,
+    Plan,
+    PlanEvent,
+    PlanState,
+    Step,
+)
 from apps.worker.olympus_worker.main import PlanExecutor
 from packages.tools.olympus_tools.fs import ConsentToken
 from .settings import get_settings
-from .middleware import BodySizeLimitMiddleware, RequestIDMiddleware, TimeoutMiddleware, TokenBucketLimiter
+from .middleware import (
+    BodySizeLimitMiddleware,
+    RequestIDMiddleware,
+    TimeoutMiddleware,
+    TokenBucketLimiter,
+)
 from .cors import build_cors_kwargs
 import asyncio
 from packages.llm.olympus_llm.router import LLMRouter
@@ -31,6 +50,7 @@ from .nl_agent import handle_chat_turn
 
 APP_NAME = "Olympus API"
 ASK_BEFORE_DOING = os.getenv("APP_ASK_BEFORE_DOING", "true").lower() == "true"
+
 
 # ---------- Logging ----------
 def log(level: str, msg: str, **fields):
@@ -42,12 +62,22 @@ def log(level: str, msg: str, **fields):
     }
     print(json.dumps(rec, ensure_ascii=False))
 
+
 # ---------- Metrics ----------
 REG = CollectorRegistry()
-REQUESTS = Counter("requests_total", "HTTP requests", ["route", "method", "code"], registry=REG)
-ERRORS = Counter("errors_total", "Errors by class", ["route", "error_class"], registry=REG)
-LAT = Histogram("request_duration_seconds", "Latency", ["route"], registry=REG,
-                buckets=(0.01, 0.05, 0.1, 0.2, 0.5, 1, 2, 5, 10))
+REQUESTS = Counter(
+    "requests_total", "HTTP requests", ["route", "method", "code"], registry=REG
+)
+ERRORS = Counter(
+    "errors_total", "Errors by class", ["route", "error_class"], registry=REG
+)
+LAT = Histogram(
+    "request_duration_seconds",
+    "Latency",
+    ["route"],
+    registry=REG,
+    buckets=(0.01, 0.05, 0.1, 0.2, 0.5, 1, 2, 5, 10),
+)
 CIRCUIT = Gauge("circuit_open", "Breaker (compat)", registry=REG)
 QUEUE_DEPTH = Gauge("queue_depth", "In-flight requests", registry=REG)
 
@@ -58,7 +88,11 @@ app = FastAPI(title=APP_NAME)
 _settings = get_settings()
 app.add_middleware(CORSMiddleware, **build_cors_kwargs(_settings))
 app.add_middleware(RequestIDMiddleware)
-app.add_middleware(TimeoutMiddleware, connect_timeout=_settings.CONNECT_TIMEOUT_SEC, request_timeout=_settings.REQUEST_TIMEOUT_SEC)
+app.add_middleware(
+    TimeoutMiddleware,
+    connect_timeout=_settings.CONNECT_TIMEOUT_SEC,
+    request_timeout=_settings.REQUEST_TIMEOUT_SEC,
+)
 app.add_middleware(BodySizeLimitMiddleware, max_bytes=_settings.MAX_BODY_BYTES)
 app.add_middleware(TokenBucketLimiter, settings=_settings)
 
@@ -67,6 +101,7 @@ try:
     app.mount("/ui", StaticFiles(directory="public", html=True), name="ui")
 except Exception:
     pass
+
 
 # ---------- Middleware ----------
 @app.middleware("http")
@@ -81,7 +116,7 @@ async def obs_mw(request: Request, call_next):
     except HTTPException as e:
         code = e.status_code
         raise
-    except Exception as e:
+    except Exception:
         code = 500
         raise
     finally:
@@ -89,6 +124,7 @@ async def obs_mw(request: Request, call_next):
         LAT.labels(route=route).observe(dur)
         REQUESTS.labels(route=route, method=method, code=str(code)).inc()
         QUEUE_DEPTH.set(0)
+
 
 # ---------- Models ----------
 class SubmitStep(BaseModel):
@@ -112,6 +148,7 @@ ROUTER = LLMRouter()
 
 # ---------- Routes ----------
 
+
 @app.get("/healthz")
 def healthz():
     return {"status": "ready", "ask_before_doing": ASK_BEFORE_DOING}
@@ -124,7 +161,7 @@ def health():
 
 @app.get("/metrics")
 def metrics():
-    return JSONResponse(generate_latest(REG), media_type=CONTENT_TYPE_LATEST)
+    return Response(generate_latest(REG), media_type=CONTENT_TYPE_LATEST)
 
 
 @app.get("/v1/config")
@@ -136,7 +173,10 @@ def config_echo():
         db = DB  # reuse
         usd = db.cache_get(f"budget:{today}") or {"value": {"usd": 0.0}}
         toks = db.cache_get(f"budget_tokens:{today}") or {"value": {"tokens": 0}}
-        cfg["LLM_USAGE_TODAY"] = {"usd": float(usd["value"].get("usd", 0.0)), "tokens": int(toks["value"].get("tokens", 0))}
+        cfg["LLM_USAGE_TODAY"] = {
+            "usd": float(usd["value"].get("usd", 0.0)),
+            "tokens": int(toks["value"].get("tokens", 0)),
+        }
     except Exception:
         cfg["LLM_USAGE_TODAY"] = {"usd": 0.0, "tokens": 0}
     return cfg
@@ -162,11 +202,21 @@ def llm_health():
         if s.OLY_LLM_BACKEND.lower() in ("llamacpp", "llama.cpp"):
             r = requests.get(f"{s.LLAMA_CPP_URL.rstrip('/')}/health", timeout=2.0)
             ok = r.status_code == 200
-            return {"backend": "llamacpp", "url": s.LLAMA_CPP_URL, "ok": ok, "status": r.status_code}
+            return {
+                "backend": "llamacpp",
+                "url": s.LLAMA_CPP_URL,
+                "ok": ok,
+                "status": r.status_code,
+            }
         else:
             r = requests.get(f"{s.OLLAMA_BASE_URL.rstrip('/')}/api/tags", timeout=2.0)
             ok = r.status_code == 200
-            return {"backend": "ollama", "url": s.OLLAMA_BASE_URL, "ok": ok, "status": r.status_code}
+            return {
+                "backend": "ollama",
+                "url": s.OLLAMA_BASE_URL,
+                "ok": ok,
+                "status": r.status_code,
+            }
     except Exception as e:
         return {"ok": False, "error": str(e), "backend": s.OLY_LLM_BACKEND}
 
@@ -222,7 +272,9 @@ def submit_plan(body: SubmitPlan, user: Dict = Depends(get_current_user)):
         row["plan_id"] = p.id
         row["max_retries"] = s.guard.max_retries
         DB.upsert_step(row)
-    DB.append_event(PlanEvent(type="plan.created", plan_id=p.id, payload={"title": p.title}).dict())
+    DB.append_event(
+        PlanEvent(type="plan.created", plan_id=p.id, payload={"title": p.title}).dict()
+    )
     return {"plan_id": p.id, "state": p.state, "steps": [s.id for s in p.steps]}
 
 
@@ -241,12 +293,23 @@ class RunBody(BaseModel):
 
 
 @app.post("/v1/plan/{plan_id}/run")
-async def run_plan(plan_id: str, background: BackgroundTasks, body: RunBody | None = None, user: Dict = Depends(get_current_user)):
+async def run_plan(
+    plan_id: str,
+    background: BackgroundTasks,
+    body: RunBody | None = None,
+    user: Dict = Depends(get_current_user),
+):
     # Execute asynchronously
     consent = None
     if body and (body.consent_token or body.consent_scopes):
-        consent = ConsentToken(token=body.consent_token or "user", scopes=body.consent_scopes or [])
-    background.add_task(EXECUTOR.run_by_id, plan_id) if consent is None else background.add_task(EXECUTOR.run_by_id_with_consent, plan_id, consent)
+        consent = ConsentToken(
+            token=body.consent_token or "user", scopes=body.consent_scopes or []
+        )
+    (
+        background.add_task(EXECUTOR.run_by_id, plan_id)
+        if consent is None
+        else background.add_task(EXECUTOR.run_by_id_with_consent, plan_id, consent)
+    )
     return {"ok": True, "plan_id": plan_id}
 
 
@@ -263,9 +326,14 @@ def act(body: ActBody, user: Dict = Depends(get_current_user)):
     Direct capability execution with explicit consent (bypasses planning).
     """
     if ASK_BEFORE_DOING and not body.consent_token:
-        raise HTTPException(status_code=403, detail={"sentinel": "OLY-ACT-401", "msg": "Consent required"})
+        raise HTTPException(
+            status_code=403,
+            detail={"sentinel": "OLY-ACT-401", "msg": "Consent required"},
+        )
 
-    consent = ConsentToken(token=body.consent_token or "explicit", scopes=body.consent_scopes or ["*"])
+    consent = ConsentToken(
+        token=body.consent_token or "explicit", scopes=body.consent_scopes or ["*"]
+    )
     # Use the same registry the worker uses
     tool = EXECUTOR.registry.resolve(body.capability)
     try:
@@ -273,7 +341,9 @@ def act(body: ActBody, user: Dict = Depends(get_current_user)):
         return {"ok": True, "output": out}
     except Exception as e:
         ERRORS.labels(route="/v1/act", error_class=type(e).__name__).inc()
-        raise HTTPException(status_code=400, detail={"sentinel": "OLY-ACT-400", "err": str(e)})
+        raise HTTPException(
+            status_code=400, detail={"sentinel": "OLY-ACT-400", "err": str(e)}
+        )
 
 
 class AgentExecuteBody(BaseModel):
@@ -295,16 +365,33 @@ async def agent_execute(body: AgentExecuteBody, user: Dict = Depends(get_current
     """
     consent = None
     if body.consent_token or body.consent_scopes:
-        consent = ConsentToken(token=body.consent_token or "user", scopes=body.consent_scopes or [])
+        consent = ConsentToken(
+            token=body.consent_token or "user", scopes=body.consent_scopes or []
+        )
 
     # Step 1: propose plan
-    plan = propose_plan(goal=body.goal, router=ROUTER, context=None, model=body.model, temperature=0.2, max_tokens=body.max_tokens)
+    plan = propose_plan(
+        goal=body.goal,
+        router=ROUTER,
+        context=None,
+        model=body.model,
+        temperature=0.2,
+        max_tokens=body.max_tokens,
+    )
     # Persist
     DB.upsert_plan(plan.dict())
     for s in plan.steps:
-        row = s.dict(); row["plan_id"] = plan.id; row["max_retries"] = s.guard.max_retries
+        row = s.dict()
+        row["plan_id"] = plan.id
+        row["max_retries"] = s.guard.max_retries
         DB.upsert_step(row)
-    DB.append_event(PlanEvent(type="plan.created", plan_id=plan.id, payload={"title": plan.title, "goal": body.goal}).dict())
+    DB.append_event(
+        PlanEvent(
+            type="plan.created",
+            plan_id=plan.id,
+            payload={"title": plan.title, "goal": body.goal},
+        ).dict()
+    )
 
     # Execute + reflect loop
     max_iter = max(0, int(body.max_iterations))
@@ -312,66 +399,109 @@ async def agent_execute(body: AgentExecuteBody, user: Dict = Depends(get_current
         # Run
         await EXECUTOR.run(plan, consent=consent)
         if plan.state == PlanState.DONE:
-            return {"plan_id": plan.id, "state": plan.state, "iterations": i, "revised": False if i == 0 else True}
+            return {
+                "plan_id": plan.id,
+                "state": plan.state,
+                "iterations": i,
+                "revised": False if i == 0 else True,
+            }
         # If failed and we can iterate, reflect & revise
         if plan.state == PlanState.FAILED and i < max_iter:
             # summarize failure
             failed_steps = [
-                {"id": s.id, "name": s.name, "capability": s.capability.name, "error": s.error}
+                {
+                    "id": s.id,
+                    "name": s.name,
+                    "capability": s.capability.name,
+                    "error": s.error,
+                }
                 for s in plan.steps
                 if s.error
             ]
             failure = {"failed_steps": failed_steps}
-            revised = reflect_and_revise(goal=body.goal, prev_plan=plan, failure=failure, router=ROUTER, model=body.model)
+            revised = reflect_and_revise(
+                goal=body.goal,
+                prev_plan=plan,
+                failure=failure,
+                router=ROUTER,
+                model=body.model,
+            )
             # overwrite plan (new id)
             plan = revised
             DB.upsert_plan(plan.dict())
             for s in plan.steps:
-                row = s.dict(); row["plan_id"] = plan.id; row["max_retries"] = s.guard.max_retries
+                row = s.dict()
+                row["plan_id"] = plan.id
+                row["max_retries"] = s.guard.max_retries
                 DB.upsert_step(row)
-            DB.append_event(PlanEvent(type="plan.created", plan_id=plan.id, payload={"title": plan.title, "goal": body.goal, "rev": i+1}).dict())
+            DB.append_event(
+                PlanEvent(
+                    type="plan.created",
+                    plan_id=plan.id,
+                    payload={"title": plan.title, "goal": body.goal, "rev": i + 1},
+                ).dict()
+            )
             # link parent and child via events
-            DB.append_event(PlanEvent(type="plan.revised", plan_id=plan.id, payload={"parent_plan_id": failure.get("plan_id", ""), "failure": failure}).dict())
-            DB.append_event(PlanEvent(type="plan.revised_to", plan_id=failure.get("plan_id", plan.id), payload={"child_plan_id": plan.id}).dict())
+            DB.append_event(
+                PlanEvent(
+                    type="plan.revised",
+                    plan_id=plan.id,
+                    payload={
+                        "parent_plan_id": failure.get("plan_id", ""),
+                        "failure": failure,
+                    },
+                ).dict()
+            )
+            DB.append_event(
+                PlanEvent(
+                    type="plan.revised_to",
+                    plan_id=failure.get("plan_id", plan.id),
+                    payload={"child_plan_id": plan.id},
+                ).dict()
+            )
             continue
         break
     return {"plan_id": plan.id, "state": plan.state, "iterations": i, "revised": i > 0}
 
 
 def build_failure_summary(plan_id: str) -> Dict[str, Any]:
-     # Collect failed steps, error messages, and recent event payloads
-     summary: Dict[str, Any] = {"plan_id": plan_id, "failed_steps": []}
-     steps = DB.get_steps(plan_id)
-     events = list(DB.events_for_plan(plan_id))
-     events_by_step: Dict[str, List[Dict[str, Any]]] = {}
-     for ev in events:
-         sid = ev.get("step_id")
-         if sid:
-             events_by_step.setdefault(sid, []).append(ev)
-     for s in steps:
-         if s.get("state") == "FAILED":
-             sid = s["id"]
-             recents = [e for e in events_by_step.get(sid, [])][-5:]
-             previews: Dict[str, Any] = {}
-             out = s.get("output") or {}
-             for k in ("stdout", "stderr", "text", "content"):
-                 v = out.get(k)
-                 if isinstance(v, str) and v:
-                     previews[k] = (v[:512] + ("..." if len(v) > 512 else ""))
-             summary["failed_steps"].append(
-                 {
-                     "id": sid,
-                     "name": s.get("name"),
-                     "capability": (s.get("capability") or {}).get("name"),
-                     "error": s.get("error"),
-                     "recent_events": [
-                         {"type": e.get("type"), "ts": e.get("ts"), "payload": e.get("payload")}
-                         for e in recents
-                     ],
-                     "output_preview": previews,
-                 }
-             )
-     return summary
+    # Collect failed steps, error messages, and recent event payloads
+    summary: Dict[str, Any] = {"plan_id": plan_id, "failed_steps": []}
+    steps = DB.get_steps(plan_id)
+    events = list(DB.events_for_plan(plan_id))
+    events_by_step: Dict[str, List[Dict[str, Any]]] = {}
+    for ev in events:
+        sid = ev.get("step_id")
+        if sid:
+            events_by_step.setdefault(sid, []).append(ev)
+    for s in steps:
+        if s.get("state") == "FAILED":
+            sid = s["id"]
+            recents = [e for e in events_by_step.get(sid, [])][-5:]
+            previews: Dict[str, Any] = {}
+            out = s.get("output") or {}
+            for k in ("stdout", "stderr", "text", "content"):
+                v = out.get(k)
+                if isinstance(v, str) and v:
+                    previews[k] = v[:512] + ("..." if len(v) > 512 else "")
+            summary["failed_steps"].append(
+                {
+                    "id": sid,
+                    "name": s.get("name"),
+                    "capability": (s.get("capability") or {}).get("name"),
+                    "error": s.get("error"),
+                    "recent_events": [
+                        {
+                            "type": e.get("type"),
+                            "ts": e.get("ts"),
+                            "payload": e.get("payload"),
+                        }
+                        for e in recents
+                    ],
+                    "output_preview": previews,
+                }
+            )
+    return summary
 
 
 class ChatBody(BaseModel):
@@ -385,10 +515,13 @@ class ChatBody(BaseModel):
 def chat_stream(body: ChatBody, user: Dict = Depends(get_current_user)):
     async def gen():
         try:
-            async for chunk in ROUTER.stream_chat(messages=body.messages, model=body.model, temperature=body.temperature):
+            async for chunk in ROUTER.stream_chat(
+                messages=body.messages, model=body.model, temperature=body.temperature
+            ):
                 yield chunk
         except Exception as e:
             yield f"[error] {type(e).__name__}: {e}"
+
     return StreamingResponse(gen(), media_type="text/event-stream")
 
 
@@ -421,17 +554,24 @@ def plan_summary(plan_id: str, user: Dict = Depends(get_current_user)):
         for k in ("stdout", "stderr", "text", "content"):
             v = out.get(k)
             if isinstance(v, str) and v:
-                preview[k] = (v[:256] + ("..." if len(v) > 256 else ""))
-        simple.append({
-            "id": s.get("id"),
-            "name": s.get("name"),
-            "capability": cap,
-            "deps": s.get("deps", []),
-            "state": s.get("state"),
-            "error": s.get("error"),
-            "output_preview": preview,
-        })
-    return {"plan_id": plan_id, "title": row.get("title"), "state": row.get("state"), "steps": simple}
+                preview[k] = v[:256] + ("..." if len(v) > 256 else "")
+        simple.append(
+            {
+                "id": s.get("id"),
+                "name": s.get("name"),
+                "capability": cap,
+                "deps": s.get("deps", []),
+                "state": s.get("state"),
+                "error": s.get("error"),
+                "output_preview": preview,
+            }
+        )
+    return {
+        "plan_id": plan_id,
+        "title": row.get("title"),
+        "state": row.get("state"),
+        "steps": simple,
+    }
 
 
 class NLBody(BaseModel):
@@ -455,41 +595,93 @@ async def agent_chat(body: NLBody, user: Dict = Depends(get_current_user)):
     )
     # Persist chat turn as events
     sess = body.session_id or str(uuid.uuid4())
-    DB.append_event(PlanEvent(type="chat.user", plan_id=sess, payload={"text": body.message}).dict())
-    DB.append_event(PlanEvent(type="chat.assistant", plan_id=sess, payload={"reply": reply}).dict())
+    DB.append_event(
+        PlanEvent(type="chat.user", plan_id=sess, payload={"text": body.message}).dict()
+    )
+    DB.append_event(
+        PlanEvent(type="chat.assistant", plan_id=sess, payload={"reply": reply}).dict()
+    )
     result = {"session_id": sess, **reply}
     if plan is not None and not reply.get("requires_consent"):
         # persist plan and run
         DB.upsert_plan(plan.dict())
         for s in plan.steps:
-            row = s.dict(); row["plan_id"] = plan.id; row["max_retries"] = s.guard.max_retries
+            row = s.dict()
+            row["plan_id"] = plan.id
+            row["max_retries"] = s.guard.max_retries
             DB.upsert_step(row)
-        DB.append_event(PlanEvent(type="plan.created", plan_id=plan.id, payload={"title": plan.title, "goal": body.message, "session_id": sess}).dict())
+        DB.append_event(
+            PlanEvent(
+                type="plan.created",
+                plan_id=plan.id,
+                payload={"title": plan.title, "goal": body.message, "session_id": sess},
+            ).dict()
+        )
         # Heuristic: escalate to reflection loop for complex goals
-        complex_goal = any(k in body.message.lower() for k in ("migrate", "refactor", "type-check", "lint", "test", "deploy"))
-        if (body.auto_escalate is True) or (body.auto_escalate is None and complex_goal):
+        complex_goal = any(
+            k in body.message.lower()
+            for k in ("migrate", "refactor", "type-check", "lint", "test", "deploy")
+        )
+        if (body.auto_escalate is True) or (
+            body.auto_escalate is None and complex_goal
+        ):
             consent = None
             if body.consent_token or (allowed_scopes and "*" not in allowed_scopes):
-                consent = ConsentToken(token=body.consent_token or "user", scopes=allowed_scopes or ["*"])
+                consent = ConsentToken(
+                    token=body.consent_token or "user", scopes=allowed_scopes or ["*"]
+                )
             DB.upsert_plan(plan.dict())
             for s in plan.steps:
-                row = s.dict(); row["plan_id"] = plan.id; row["max_retries"] = s.guard.max_retries
+                row = s.dict()
+                row["plan_id"] = plan.id
+                row["max_retries"] = s.guard.max_retries
                 DB.upsert_step(row)
-            DB.append_event(PlanEvent(type="plan.created", plan_id=plan.id, payload={"title": plan.title, "goal": body.message, "session_id": sess}).dict())
+            DB.append_event(
+                PlanEvent(
+                    type="plan.created",
+                    plan_id=plan.id,
+                    payload={
+                        "title": plan.title,
+                        "goal": body.message,
+                        "session_id": sess,
+                    },
+                ).dict()
+            )
             cur = plan
             for i in range(2 + 1):
                 await EXECUTOR.run(cur, consent=consent)
                 if cur.state == PlanState.DONE:
-                    result.update({"plan_id": cur.id, "state": cur.state, "iterations": i})
+                    result.update(
+                        {"plan_id": cur.id, "state": cur.state, "iterations": i}
+                    )
                     break
                 if cur.state == PlanState.FAILED and i < 2:
                     failure = build_failure_summary(cur.id)
-                    revised = reflect_and_revise(goal=body.message, prev_plan=cur, failure=failure, router=ROUTER, model=None)
+                    revised = reflect_and_revise(
+                        goal=body.message,
+                        prev_plan=cur,
+                        failure=failure,
+                        router=ROUTER,
+                        model=None,
+                    )
                     DB.upsert_plan(revised.dict())
                     for s in revised.steps:
-                        row = s.dict(); row["plan_id"] = revised.id; row["max_retries"] = s.guard.max_retries
+                        row = s.dict()
+                        row["plan_id"] = revised.id
+                        row["max_retries"] = s.guard.max_retries
                         DB.upsert_step(row)
-                    DB.append_event(PlanEvent(type="plan.created", plan_id=revised.id, payload={"title": revised.title, "goal": body.message, "session_id": sess, "rev": i+1}).dict())
+                    DB.append_event(
+                        PlanEvent(
+                            type="plan.created",
+                            plan_id=revised.id,
+                            payload={
+                                "title": revised.title,
+                                "goal": body.message,
+                                "session_id": sess,
+                                "rev": i + 1,
+                            },
+                        ).dict()
+                    )
                     cur = revised
                     continue
                 result.update({"plan_id": cur.id, "state": cur.state, "iterations": i})
@@ -497,9 +689,21 @@ async def agent_chat(body: NLBody, user: Dict = Depends(get_current_user)):
         else:
             DB.upsert_plan(plan.dict())
             for s in plan.steps:
-                row = s.dict(); row["plan_id"] = plan.id; row["max_retries"] = s.guard.max_retries
+                row = s.dict()
+                row["plan_id"] = plan.id
+                row["max_retries"] = s.guard.max_retries
                 DB.upsert_step(row)
-            DB.append_event(PlanEvent(type="plan.created", plan_id=plan.id, payload={"title": plan.title, "goal": body.message, "session_id": sess}).dict())
+            DB.append_event(
+                PlanEvent(
+                    type="plan.created",
+                    plan_id=plan.id,
+                    payload={
+                        "title": plan.title,
+                        "goal": body.message,
+                        "session_id": sess,
+                    },
+                ).dict()
+            )
             await EXECUTOR.run(plan)
             result.update({"plan_id": plan.id, "state": plan.state})
     return result
@@ -528,7 +732,9 @@ def agent_trace(plan_id: str, user: Dict = Depends(get_current_user)):
         plan = DB.get_plan(cur)
         if not plan:
             break
-        chain.append({"plan_id": cur, "title": plan.get("title"), "state": plan.get("state")})
+        chain.append(
+            {"plan_id": cur, "title": plan.get("title"), "state": plan.get("state")}
+        )
         next_id = None
         for ev in DB.events_for_plan(cur):
             if ev.get("type") == "plan.revised_to":

--- a/apps/api/pyproject.toml
+++ b/apps/api/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
   "python-dotenv>=1.0.1",
   "httpx>=0.27.0",
   "prometheus-client>=0.20.0",
+  "PyJWT>=2.8",
 ]
 
 [tool.setuptools]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,3 +4,4 @@ black>=24.4
 ruff>=0.5
 httpx>=0.27
 psycopg2-binary
+PyJWT>=2.8

--- a/scripts/smoke.py
+++ b/scripts/smoke.py
@@ -1,0 +1,25 @@
+import time
+import threading
+import sys
+import pathlib
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from uvicorn import Config, Server
+from apps.api.olympus_api.main import app
+
+cfg = Config(app=app, host="127.0.0.1", port=8000, log_level="warning")
+svr = Server(cfg)
+thread = threading.Thread(target=lambda: sys.exit(svr.run()))
+thread.daemon = True
+thread.start()
+
+time.sleep(1.0)
+
+import httpx
+with httpx.Client() as client:
+    resp = client.get("http://127.0.0.1:8000/health")
+    assert resp.status_code == 200
+    resp = client.get("http://127.0.0.1:8000/metrics")
+    assert resp.status_code == 200
+print("OK")


### PR DESCRIPTION
## Summary
- add dedicated smoke test script and wire into Makefile
- return proper text response from /metrics endpoint
- include PyJWT dependency and document smoke test usage

## Testing
- `make fmt`
- `make lint`
- `make type`
- `make test` *(fails: symlink test FileNotFoundError; metrics test returns 429)*
- `make smoke`


------
https://chatgpt.com/codex/tasks/task_b_68a6028ea4d08330b5b880259c5f9731