### PR TITLE
test: remove deprecated asyncio and httpx usage

### DIFF
--- a/tests/test_limits.py
+++ b/tests/test_limits.py
@@ -5,7 +5,7 @@ from olympus_api.main import app
 def test_body_size_limit(monkeypatch):
     monkeypatch.setenv("MAX_BODY_BYTES", "10")
     client = TestClient(app)
-    resp = client.post("/v1/dev/sleep", data="x" * 100)
+    resp = client.post("/v1/dev/sleep", content="x" * 100)
     assert resp.status_code in (405, 413)
 
 

--- a/tests/test_llm_router.py
+++ b/tests/test_llm_router.py
@@ -4,7 +4,7 @@ from olympus_llm.router import LLMRouter, ModelNotAllowedError
 
 
 def run(coro):
-    return asyncio.get_event_loop().run_until_complete(coro)
+    return asyncio.run(coro)
 
 
 def test_allowlist_enforced(monkeypatch):


### PR DESCRIPTION
### **User description**
## Summary
- replace deprecated asyncio.get_event_loop usage in tests with asyncio.run
- switch httpx TestClient calls to use `content=` to avoid deprecation warnings

## Testing
- `ruff check tests/test_llm_router.py tests/test_limits.py --fix`
- `black tests/test_llm_router.py tests/test_limits.py`
- `mypy apps packages services` *(fails: Duplicate module named "main")*
- `pytest tests/test_llm_router.py tests/test_limits.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68c6e84bb3408330878cecafef47d6a5


___

### **PR Type**
Tests


___

### **Description**
- Replace deprecated `asyncio.get_event_loop()` with `asyncio.run()`

- Update httpx TestClient to use `content=` parameter


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Deprecated asyncio.get_event_loop()"] --> B["Modern asyncio.run()"]
  C["TestClient data= parameter"] --> D["TestClient content= parameter"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_limits.py</strong><dd><code>Update TestClient parameter usage</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_limits.py

<ul><li>Replace deprecated <code>data=</code> parameter with <code>content=</code> in TestClient POST <br>request</ul>


</details>


  </td>
  <td><a href="https://github.com/Senpai-Sama7/Olympus-AI/pull/9/files#diff-5308bb11aed81c0eabcfdeff5b59a2b4a51ed182d8005fc2a003d9f91a1e4474">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_llm_router.py</strong><dd><code>Modernize asyncio usage</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_llm_router.py

<ul><li>Replace deprecated <code>asyncio.get_event_loop().run_until_complete()</code> with <br><code>asyncio.run()</code></ul>


</details>


  </td>
  <td><a href="https://github.com/Senpai-Sama7/Olympus-AI/pull/9/files#diff-39d216ff0945760413c0efbd87c1066cb59e5c007de0ccd835ed48bca63be4a7">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

